### PR TITLE
Fix ACLs for Confluent Kafka Cluster

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -233,6 +233,7 @@ resource "confluent_kafka_acl" "group_readers" {
     secret = confluent_api_key.service_account_api_keys[each.value].secret
   }
 }
+
 /*
  New realisation of ACL
 */


### PR DESCRIPTION
With current logic of ACL management we are planning to create 179*29 = 5191 ACL resources. It is definitely not what we want. We should change the logic of module to reduce number of ACL resources.
It would be much better of course to create only 29 ACLs: one per account. Or just one ACL to rule them all.