### PR TITLE
Fix issue where ccloud_exporter can't fetch Confluent Cloud metrics

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -126,6 +126,7 @@ resource "confluent_role_binding" "ccloud_exporter_sa_cluster_role_binding" {
   role_name   = "MetricsViewer"
   crn_pattern = confluent_kafka_cluster.cluster.rbac_crn
 }
+
 # Ccloud Exporter API Key
 resource "confluent_api_key" "ccloud_exporter_api_key" {
   count = var.enable_metric_exporters ? 1 : 0
@@ -138,15 +139,6 @@ resource "confluent_api_key" "ccloud_exporter_api_key" {
     kind        = confluent_service_account.ccloud_exporter_service_account.kind
   }
 
-  managed_resource {
-    id          = confluent_kafka_cluster.cluster.id
-    api_version = confluent_kafka_cluster.cluster.api_version
-    kind        = confluent_kafka_cluster.cluster.kind
-
-    environment {
-      id = confluent_environment.environment.id
-    }
-  }
   depends_on = [
     confluent_role_binding.ccloud_exporter_sa_cluster_role_binding
   ]
@@ -259,5 +251,3 @@ resource "confluent_kafka_acl" "group_readers" {
     secret = confluent_api_key.service_account_api_keys[each.value].secret
   }
 }
-
-


### PR DESCRIPTION
ccloud exporter doesn't work currently. Here is an error from log:
```
Received status code 403 instead of 200 for GET on https://api.telemetry.confluent.cloud/v2/metrics/cloud/descriptors/resources.
{"error":{"code":403,"message":"invalid API key: make sure you're using a Cloud API Key and not a Cluster API Key: https://docs.confluent.io/cloud/current/api.html#section/Authentication"}}
```

According to this message Cloud API Key should be used to fetch metrics instead of Kafka API Key.

Confluent Cloud Terraform Provider [docs](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_api_key#managed_resource) say that we should omit `managed_resource` block in `confluent_api_key` definition in order to create Cloud API Key.