### PR TITLE
Grant ccloud exporter environment wide access

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -124,7 +124,7 @@ resource "confluent_service_account" "ccloud_exporter_service_account" {
 resource "confluent_role_binding" "ccloud_exporter_sa_cluster_role_binding" {
   principal   = "User:${confluent_service_account.ccloud_exporter_service_account.id}"
   role_name   = "MetricsViewer"
-  crn_pattern = confluent_kafka_cluster.cluster.rbac_crn
+  crn_pattern = confluent_environment.environment.resource_name
 }
 
 # Ccloud Exporter API Key


### PR DESCRIPTION
Currently ccloud_exporter exposes only metrics for kafka cluster itself but not for cluster link.
Since ClusterLink is not a part of Cluster it's not enough to have MetricsViewer role in cluster scope to fetch Link metrics.

This PR binds ccloud_exporter service account to a MetricsViewer role in environment scope.