### PR TITLE
Add ccloud exporter config

### DIFF
--- a/ccloud-exporter.tf
+++ b/ccloud-exporter.tf
@@ -17,6 +17,21 @@ resource "kubernetes_service_account" "ccloud_exporter_service_account" {
   }
 }
 
+
+resource "kubernetes_secret" "ccloud_exporter_config_file" {
+  count = var.enable_metric_exporters ? 1 : 0
+
+  metadata {
+    name      = "${local.ccloud_exporter_name}-config-file"
+    namespace = var.metric_exporters_namespace
+    labels    = local.ccloud_exporter_common_labels
+  }
+
+  data = {
+    "config.yaml" = file("${path.module}/templates/ccloud-exporter.yaml")
+  }
+}
+
 resource "kubernetes_secret" "ccloud_exporter_config" {
   count = var.enable_metric_exporters ? 1 : 0
 
@@ -74,6 +89,8 @@ resource "kubernetes_deployment" "ccloud_exporter_deployment" {
           # Repo recommends pointing to master
           image_pull_policy = "Always"
 
+          command = ["-config", "/opt/docker/conf/config.yaml"]
+
           resources {
             requests = var.ccloud_exporter_container_resources.requests
             limits   = var.ccloud_exporter_container_resources.limits
@@ -83,6 +100,12 @@ resource "kubernetes_deployment" "ccloud_exporter_deployment" {
             secret_ref {
               name = kubernetes_secret.ccloud_exporter_config[0].metadata.0.name
             }
+          }
+
+          volume_mount {
+            mount_path = "/opt/docker/conf/"
+            name       = "config"
+            read_only  = true
           }
 
           port {
@@ -115,6 +138,13 @@ resource "kubernetes_deployment" "ccloud_exporter_deployment" {
             timeout_seconds       = 30
             failure_threshold     = 3
             success_threshold     = 1
+          }
+        }
+
+        volume {
+          name = "config"
+          secret {
+            secret_name = kubernetes_secret.ccloud_exporter_config_file[0].metadata.0.name
           }
         }
       }

--- a/ccloud-exporter.tf
+++ b/ccloud-exporter.tf
@@ -28,7 +28,12 @@ resource "kubernetes_secret" "ccloud_exporter_config_file" {
   }
 
   data = {
-    "config.yaml" = file("${path.module}/templates/ccloud-exporter.yaml")
+    "config.yaml" = templatefile(
+      "${path.module}/templates/ccloud-exporter.yaml",
+      {
+        cluster_id = confluent_kafka_cluster.cluster.id
+      }
+    )
   }
 }
 
@@ -44,7 +49,6 @@ resource "kubernetes_secret" "ccloud_exporter_config" {
   data = {
     CCLOUD_API_KEY    = confluent_api_key.ccloud_exporter_api_key[0].id
     CCLOUD_API_SECRET = confluent_api_key.ccloud_exporter_api_key[0].secret
-    CCLOUD_CLUSTER    = confluent_kafka_cluster.cluster.id
   }
 }
 

--- a/ccloud-exporter.tf
+++ b/ccloud-exporter.tf
@@ -93,7 +93,7 @@ resource "kubernetes_deployment" "ccloud_exporter_deployment" {
           # Repo recommends pointing to master
           image_pull_policy = "Always"
 
-          command = ["-config", "/opt/docker/conf/config.yaml"]
+          args = ["-config", "/opt/docker/conf/config.yaml"]
 
           resources {
             requests = var.ccloud_exporter_container_resources.requests

--- a/templates/ccloud-exporter.yaml
+++ b/templates/ccloud-exporter.yaml
@@ -6,16 +6,13 @@ config:
   noTimestamp: false
   delay: 60
   granularity: PT1M
-  cachedSecond: 30
+  cachedSecond: 60
 rules:
   - clusters:
-      - $CCLOUD_CLUSTER
-    connectors:
-      - $CCLOUD_CONNECTOR
-    ksqls:
-      - $CCLOUD_KSQL
-    schemaRegistries:
-      - $CCLOUD_SCHEMA_REGISTRY
+      - ${cluster_id}
+    connectors: []
+    ksqls: []
+    schemaRegistries: []
     metrics:
       - io.confluent.kafka.server/received_bytes
       - io.confluent.kafka.server/sent_bytes
@@ -31,14 +28,9 @@ rules:
       - io.confluent.kafka.server/cluster_link_mirror_topic_offset_lag
       - io.confluent.kafka.server/cluster_link_mirror_topic_bytes
       - io.confluent.kafka.server/cluster_load_percent
-      - io.confluent.kafka.connect/sent_bytes
-      - io.confluent.kafka.connect/received_bytes
-      - io.confluent.kafka.connect/received_records
-      - io.confluent.kafka.connect/sent_records
-      - io.confluent.kafka.connect/dead_letter_queue_records
-      - io.confluent.kafka.ksql/streaming_unit_count
-      - io.confluent.kafka.schema_registry/schema_count
     labels:
       - kafka_id
       - topic
       - type
+      - link_name
+      - link_mirror_topic_state

--- a/templates/ccloud-exporter.yaml
+++ b/templates/ccloud-exporter.yaml
@@ -1,0 +1,44 @@
+config:
+  http:
+    baseurl: https://api.telemetry.confluent.cloud/
+    timeout: 60
+  listener: 0.0.0.0:2112
+  noTimestamp: false
+  delay: 60
+  granularity: PT1M
+  cachedSecond: 30
+rules:
+  - clusters:
+      - $CCLOUD_CLUSTER
+    connectors:
+      - $CCLOUD_CONNECTOR
+    ksqls:
+      - $CCLOUD_KSQL
+    schemaRegistries:
+      - $CCLOUD_SCHEMA_REGISTRY
+    metrics:
+      - io.confluent.kafka.server/received_bytes
+      - io.confluent.kafka.server/sent_bytes
+      - io.confluent.kafka.server/received_records
+      - io.confluent.kafka.server/sent_records
+      - io.confluent.kafka.server/retained_bytes
+      - io.confluent.kafka.server/active_connection_count
+      - io.confluent.kafka.server/request_count
+      - io.confluent.kafka.server/partition_count
+      - io.confluent.kafka.server/successful_authentication_count
+      - io.confluent.kafka.server/consumer_lag_offsets
+      - io.confluent.kafka.server/cluster_link_mirror_topic_count
+      - io.confluent.kafka.server/cluster_link_mirror_topic_offset_lag
+      - io.confluent.kafka.server/cluster_link_mirror_topic_bytes
+      - io.confluent.kafka.server/cluster_load_percent
+      - io.confluent.kafka.connect/sent_bytes
+      - io.confluent.kafka.connect/received_bytes
+      - io.confluent.kafka.connect/received_records
+      - io.confluent.kafka.connect/sent_records
+      - io.confluent.kafka.connect/dead_letter_queue_records
+      - io.confluent.kafka.ksql/streaming_unit_count
+      - io.confluent.kafka.schema_registry/schema_count
+    labels:
+      - kafka_id
+      - topic
+      - type


### PR DESCRIPTION
Looks like the [default list](https://github.com/Dabz/ccloudexporter/blob/master/cmd/internal/collector/context.go#L61) of metrics in ccloud-exporter code is obsolete and incomplete.
It lacks these metrics that were added to Confluent Cloud Telemetry after ccloud-exporter development have been stopped:
- io.confluent.kafka.server/consumer_lag_offsets
- io.confluent.kafka.server/cluster_link_mirror_topic_count
- io.confluent.kafka.server/cluster_link_mirror_topic_offset_lag
- io.confluent.kafka.server/cluster_link_mirror_topic_bytes
- io.confluent.kafka.server/cluster_load_percent

This PR adds config file for ccloud-exporter that provides relevant lists of metrics and labels.