### PR TITLE
Confluent allows a 60 second refresh - set the dashboard refresh to same

### DIFF
--- a/templates/ccloud-exporter.json
+++ b/templates/ccloud-exporter.json
@@ -2173,7 +2173,7 @@
             "type": "row"
         }
     ],
-    "refresh": "5s",
+    "refresh": "1m",
     "schemaVersion": 27,
     "style": "dark",
     "tags": [],


### PR DESCRIPTION
Update the default refresh for the Confluent ccloud dashboard to match the interval we're allowed to scrape.