### PR TITLE
More tweaks to prevent rate limiting

### DIFF
--- a/ccloud-exporter.tf
+++ b/ccloud-exporter.tf
@@ -120,7 +120,7 @@ resource "kubernetes_deployment" "ccloud_exporter_deployment" {
 
           readiness_probe {
             http_get {
-              path = "/metrics"
+              path = "/health"
               port = "http"
             }
 
@@ -133,7 +133,7 @@ resource "kubernetes_deployment" "ccloud_exporter_deployment" {
 
           liveness_probe {
             http_get {
-              path = "/metrics"
+              path = "/health"
               port = "http"
             }
 

--- a/ccloud-exporter.tf
+++ b/ccloud-exporter.tf
@@ -67,6 +67,12 @@ resource "kubernetes_deployment" "ccloud_exporter_deployment" {
   spec {
     replicas = 1
 
+    # Kill all existing Pods before creating new ones
+    # to avoid possible rate limiting
+    strategy {
+      type = "Recreate"
+    }
+
     selector {
       match_labels = local.ccloud_exporter_common_labels
     }


### PR DESCRIPTION
- Use proper endpoint for health checks
- Change update strategy to Recreate to prevent running two pods in the same time