### PR TITLE
Provide defaults for exporter versions; exclude ccloud service when appropriate

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -116,12 +116,14 @@ resource "confluent_api_key" "service_account_api_keys" {
 
 # Ccloud Exporter Service Account
 resource "confluent_service_account" "ccloud_exporter_service_account" {
+  count = var.enable_metric_exporters ? 1 : 0
   display_name = "${local.name}-ccloud-exporter-service-account"
   description  = "Service Account for Ccloud Exporter"
 }
 
 # Ccloud Exporter Service Account Role Binding
 resource "confluent_role_binding" "ccloud_exporter_sa_cluster_role_binding" {
+  count = var.enable_metric_exporters ? 1 : 0
   principal   = "User:${confluent_service_account.ccloud_exporter_service_account.id}"
   role_name   = "MetricsViewer"
   crn_pattern = confluent_kafka_cluster.cluster.rbac_crn

--- a/variables.tf
+++ b/variables.tf
@@ -80,6 +80,7 @@ variable "kafka_lag_exporter_annotations" {
 variable "kafka_lag_exporter_image_version" {
   description = "See https://github.com/seglo/kafka-lag-exporter/releases"
   type        = string
+  default     = "0.7.1"
 }
 
 variable "kafka_lag_exporter_container_resources" {
@@ -118,6 +119,7 @@ variable "exporters_node_selector" {
 variable "ccloud_exporter_image_version" {
   description = "Exporter Image Version"
   type        = string
+  default     = "latest"
 }
 
 variable "ccloud_exporter_container_resources" {


### PR DESCRIPTION
Currently, the module asks for exporter versions, even if they have been disabled.  Additionally, a service account for ccloud exporter is created even if the exporters have been disabled.  This provides current sane defaults for exporter versions, as well as `count`s to exclude the ccloud service account if exporters are disabled.