### PR TITLE
added env & cluster id outputs | added count index

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -124,7 +124,7 @@ resource "confluent_service_account" "ccloud_exporter_service_account" {
 # Ccloud Exporter Service Account Role Binding
 resource "confluent_role_binding" "ccloud_exporter_sa_cluster_role_binding" {
   count = var.enable_metric_exporters ? 1 : 0
-  principal   = "User:${confluent_service_account.ccloud_exporter_service_account.id}"
+  principal   = "User:${confluent_service_account.ccloud_exporter_service_account[count.index].id}"
   role_name   = "MetricsViewer"
   crn_pattern = confluent_kafka_cluster.cluster.rbac_crn
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,3 +18,16 @@ output "admin_api_key" {
   value       = confluent_api_key.admin_api_key
   sensitive   = true
 }
+
+
+output "cluster_id" {
+  description = "The confluent kafka cluster id"
+  value       = confluent_kafka_cluster.cluster.id
+  sensitive   = true
+}
+
+output "confluent_environment" {
+  description = "The confluent environment id"
+  value       = confluent_environment.environment.id
+  sensitive   = true
+}


### PR DESCRIPTION
Fixes the following [error](https://github.com/dapperlabs/terraform/pull/3042#issuecomment-1270343506) when run agains `v0.12.1` and adds `confluent environment / cluster id` as outputs

```
running "/atlantis/bin/terraform1.0.6 plan -input=false -refresh -out \"/atlantis/repos/dapperlabs/terraform/3042/default/Dapperlabs-Data/Dapperlabs-Data-default.tfplan\"" in "/atlantis/repos/dapperlabs/terraform/3042/default/Dapperlabs-Data": exit status 1
╷
│ Error: Missing resource instance key
│ 
│   on .terraform/modules/confluent_kafka_cluster_staging/main.tf line 127, in resource "confluent_role_binding" "ccloud_exporter_sa_cluster_role_binding":
│  127:   principal   = "User:${confluent_service_account.ccloud_exporter_service_account.id}"
│ 
│ Because confluent_service_account.ccloud_exporter_service_account has
│ "count" set, its attributes must be accessed on specific instances.
│ 
│ For example, to correlate with indices of a referring resource, use:
│     confluent_service_account.ccloud_exporter_service_account[count.index]
╵
```