### PR TITLE
update ccloud_exporter_service_account references with count[index]

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -136,9 +136,9 @@ resource "confluent_api_key" "ccloud_exporter_api_key" {
   display_name = "${local.name} ccloud exporter api key"
   description  = "${local.name} ccloud exporter api key"
   owner {
-    id          = confluent_service_account.ccloud_exporter_service_account.id
-    api_version = confluent_service_account.ccloud_exporter_service_account.api_version
-    kind        = confluent_service_account.ccloud_exporter_service_account.kind
+    id          = confluent_service_account.ccloud_exporter_service_account[count.index].id
+    api_version = confluent_service_account.ccloud_exporter_service_account[count.index].api_version
+    kind        = confluent_service_account.ccloud_exporter_service_account[count.index].kind
   }
 
   depends_on = [


### PR DESCRIPTION
- Updates `ccloud_exporter_service_account` references with count[index] to [address](https://github.com/dapperlabs/terraform/pull/3042#issuecomment-1272150449) :

```sh
running "/atlantis/bin/terraform1.0.6 plan -input=false -refresh -out \"/atlantis/repos/dapperlabs/terraform/3042/default/Dapperlabs-Data/Dapperlabs-Data-default.tfplan\"" in "/atlantis/repos/dapperlabs/terraform/3042/default/Dapperlabs-Data": exit status 1
╷
│ Error: Missing resource instance key
│ 
│   on .terraform/modules/confluent_kafka_cluster_staging/main.tf line 139, in resource "confluent_api_key" "ccloud_exporter_api_key":
│  139:     id          = confluent_service_account.ccloud_exporter_service_account.id
│ 
│ Because confluent_service_account.ccloud_exporter_service_account has
│ "count" set, its attributes must be accessed on specific instances.
│ 
│ For example, to correlate with indices of a referring resource, use:
│     confluent_service_account.ccloud_exporter_service_account[count.index]
╵
╷
│ Error: Missing resource instance key
│ 
│   on .terraform/modules/confluent_kafka_cluster_staging/main.tf line 140, in resource "confluent_api_key" "ccloud_exporter_api_key":
│  140:     api_version = confluent_service_account.ccloud_exporter_service_account.api_version
│ 
│ Because confluent_service_account.ccloud_exporter_service_account has
│ "count" set, its attributes must be accessed on specific instances.
│ 
│ For example, to correlate with indices of a referring resource, use:
│     confluent_service_account.ccloud_exporter_service_account[count.index]
╵
╷
│ Error: Missing resource instance key
│ 
│   on .terraform/modules/confluent_kafka_cluster_staging/main.tf line 141, in resource "confluent_api_key" "ccloud_exporter_api_key":
│  141:     kind        = confluent_service_account.ccloud_exporter_service_account.kind
│ 
│ Because confluent_service_account.ccloud_exporter_service_account has
│ "count" set, its attributes must be accessed on specific instances.
│ 
│ For example, to correlate with indices of a referring resource, use:
│     confluent_service_account.ccloud_exporter_service_account[count.index]
```