### PR TITLE
Add resources and variables to manage roles for users

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,7 @@ resource "confluent_api_key" "admin_api_key" {
 
 # Users Role Bindings
 data "confluent_user" "rbac_users" {
-  for_each = local.rbac_users
+  for_each = toset(local.rbac_users)
   email    = each.value
 }
 

--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ locals {
   rbac_users = distinct(
     concat(
       keys(var.environment_user_roles),
-      keys(var.luster_user_roles),
+      keys(var.cluster_user_roles),
     )
   )
 }
@@ -150,14 +150,14 @@ resource "confluent_api_key" "service_account_api_keys" {
 
 # Ccloud Exporter Service Account
 resource "confluent_service_account" "ccloud_exporter_service_account" {
-  count = var.enable_metric_exporters ? 1 : 0
+  count        = var.enable_metric_exporters ? 1 : 0
   display_name = "${local.name}-ccloud-exporter-service-account"
   description  = "Service Account for Ccloud Exporter"
 }
 
 # Ccloud Exporter Service Account Role Binding
 resource "confluent_role_binding" "ccloud_exporter_sa_cluster_role_binding" {
-  count = var.enable_metric_exporters ? 1 : 0
+  count       = var.enable_metric_exporters ? 1 : 0
   principal   = "User:${confluent_service_account.ccloud_exporter_service_account[count.index].id}"
   role_name   = "MetricsViewer"
   crn_pattern = confluent_kafka_cluster.cluster.rbac_crn

--- a/main.tf
+++ b/main.tf
@@ -114,7 +114,7 @@ resource "confluent_role_binding" "cluster_role_binding" {
   crn_pattern = confluent_kafka_cluster.cluster.rbac_crn
 }
 
-resource "confluent_role_binding" "environment_role_binding-example-rb" {
+resource "confluent_role_binding" "environment_role_binding" {
   for_each    = { for rb in local.environment_user_roles_list : "${rb.user}/${rb.role}" => rb }
   principal   = "User:${data.confluent_user.rbac_users[each.value.user].id}"
   role_name   = each.value.role

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,7 @@ variable "topics" {
 variable "environment_user_roles" {
   description = "Map of users with list of roles for Environment-level access"
   type        = map(list(string))
-  default     = []
+  default     = {}
 
   validation {
     condition = alltrue([for role in flatten(values(var.environment_user_roles)) : contains([
@@ -46,7 +46,7 @@ variable "environment_user_roles" {
 variable "cluster_user_roles" {
   description = "Map of users with list of roles for Cluster-level access"
   type        = map(list(string))
-  default     = []
+  default     = {}
 
   validation {
     condition = alltrue([for role in flatten(values(var.cluster_user_roles)) : contains([

--- a/variables.tf
+++ b/variables.tf
@@ -30,6 +30,32 @@ variable "topics" {
   )
 }
 
+variable "environment_user_roles" {
+  description = "Map of users with list of roles for Environment-level access"
+  type        = map(list(string))
+  default     = []
+
+  validation {
+    condition = alltrue([for role in flatten(values(var.environment_user_roles)) : contains([
+      "EnvironmentAdmin", "Operator", "MetricsViewer"
+    ], role)])
+    error_message = "Bad environment role (should be one of \"EnvironmentAdmin\", \"Operator\" or \"MetricsViewer\")"
+  }
+}
+
+variable "cluster_user_roles" {
+  description = "Map of users with list of roles for Cluster-level access"
+  type        = map(list(string))
+  default     = []
+
+  validation {
+    condition = alltrue([for role in flatten(values(var.cluster_user_roles)) : contains([
+      "CloudClusterAdmin", "Operator", "MetricsViewer"
+    ], role)])
+    error_message = "Bad cluster role (should be one of \"CloudClusterAdmin\", \"Operator\" or \"MetricsViewer\")"
+  }
+}
+
 variable "add_service_account_suffix" {
   description = "Add pet name suffix to service account names to avoid collision"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,7 @@ variable "environment_user_roles" {
     condition = alltrue([for role in flatten(values(var.environment_user_roles)) : contains([
       "EnvironmentAdmin", "Operator", "MetricsViewer"
     ], role)])
-    error_message = "Bad environment role (should be one of \"EnvironmentAdmin\", \"Operator\" or \"MetricsViewer\")"
+    error_message = "Bad environment role (should be one of \"EnvironmentAdmin\", \"Operator\" or \"MetricsViewer\")."
   }
 }
 
@@ -52,7 +52,7 @@ variable "cluster_user_roles" {
     condition = alltrue([for role in flatten(values(var.cluster_user_roles)) : contains([
       "CloudClusterAdmin", "Operator", "MetricsViewer"
     ], role)])
-    error_message = "Bad cluster role (should be one of \"CloudClusterAdmin\", \"Operator\" or \"MetricsViewer\")"
+    error_message = "Bad cluster role (should be one of \"CloudClusterAdmin\", \"Operator\" or \"MetricsViewer\")."
   }
 }
 


### PR DESCRIPTION
Though Confluent allows managing user rolebindings using Web UI, it is obscure and not very convenient.

This PR adds ability to assign roles for existing users by specifying them in terraform module arguments.