### PR TITLE
Separate CCloud annotations

### DIFF
--- a/ccloud-exporter.tf
+++ b/ccloud-exporter.tf
@@ -62,7 +62,7 @@ resource "kubernetes_deployment" "ccloud_exporter_deployment" {
     name      = local.ccloud_exporter_name
     namespace = var.metric_exporters_namespace
     labels    = local.ccloud_exporter_common_labels
-    annotations = var.kafka_lag_exporter_annotations
+    annotations = var.ccloud_exporter_annotations
   }
 
   spec {
@@ -87,7 +87,7 @@ resource "kubernetes_deployment" "ccloud_exporter_deployment" {
           "prometheus.io/path"   = "/metrics"
           "prometheus.io/scrape" = "true"
         },
-          var.kafka_lag_exporter_annotations,
+          var.ccloud_exporter_annotations,
         )
       }
 

--- a/variables.tf
+++ b/variables.tf
@@ -77,6 +77,12 @@ variable "kafka_lag_exporter_annotations" {
   default     = {}
 }
 
+variable "ccloud_exporter_annotations" {
+  description = "CCloud exporter annotations"
+  type        = map(string)
+  default     = {}
+}
+
 variable "kafka_lag_exporter_image_version" {
   description = "See https://github.com/seglo/kafka-lag-exporter/releases"
   type        = string


### PR DESCRIPTION
This gives Ccloud its own variable not really much of big deal for now, but just in case we want to have different annotations for ccloud deployments in the future, this will help.